### PR TITLE
Manual unique id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
-## [1.2.0] - 2019-10-01
+## [TO BE DEPRECATED]
+- Last argument of Selectors will stop being assigned as "defaultValue". To define default value, it will be mandatory to pass an options object as last argument, containing a "defaultValue" property.
+
+## [1.2.0] - 2019-10-03
+### Added
+- Accept options object in Origin constructor as last argument.
+- Assign to the `_id` private property the value received in new option "uuid", when received.
+- Last argument in Selectors now can be an object containing "defaultValue" and/or "uuid" options.
+
+### Changed
+- `_id` private property now is a hash of default id and default value
+- Objects without query now will emit "undefined" as "_queryId" property in "cleanAny" events, instead of "null".
+
 ### Fixed
 - Emit `_root` property on cleanAny events of Selectors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Last argument in Selectors now can be an object containing "defaultValue" and/or "uuid" options.
 
 ### Changed
-- `_id` private property now is a hash of default id and default value
+- `_id` private property now is a hash of default id and default value (if no "uuid" option is received)
 - Objects without query now will emit "undefined" as "_queryId" property in "cleanAny" events, instead of "null".
 
 ### Fixed

--- a/docs/origin/api.md
+++ b/docs/origin/api.md
@@ -6,26 +6,28 @@ To create a new `Origin`, you should extend from the Mercury `Origin` Class, def
 
 If you don't define one of this methods, the correspondant CRUD method will not be available in the resultant Origin.
 
-The Constructor requires two arguments. Call `super` from your own constructor, passing:
-* `super([id, defaultValue])`
-  * Arguments:
-    * `id` Used for debugging purposes.
-    * `defaultValue` Resultant origin will have this value in the `value` property until data is fetched.
+Call `super` from your own constructor, passing:
+* `super([id, defaultValue, options])`
+	* Arguments:
+		* `defaultId` Used for debugging purposes. The `_id` of the resultant source will be a hash calculated using this default id and default value.
+		* `defaultValue` Resultant origin will have this value in the `value` property until data is fetched.
+		* `options` Object containing another options, such as:
+			* `uuid` If provided, the resultant instance will have this property as `_id`. It will not be "hashed".
 
 Crud methods will receive two arguments:
 
 * `_read([query, extraParams])`
-  * Arguments:
-    * `query` If origin is queried, you will receive here the current query.
-    * `extraParams` Extra data passed as argument when the method is invoked.
-  * Returns: `<Promise>`
+	* Arguments:
+		* `query` If origin is queried, you will receive here the current query.
+		* `extraParams` Extra data passed as argument when the method is invoked.
+	* Returns: `<Promise>`
 
 Available methods for internal usage:
 
 * `this._cache` Use built-in cache to provide cache to your Origin.
-  * `this._cache.set(query, value)`. Set cache for an specific query. Cached objects should be Promises, in order to provide cache too for parallel invokations.
-  * `this._cache.get(query)`. Returns cache for an specific query.
-  * `this._cache.clean([query])`. Clean cache of an specific query. Cleans all caches if no query is provided.
+	* `this._cache.set(query, value)`. Set cache for an specific query. Cached objects should be Promises, in order to provide cache too for parallel invokations.
+	* `this._cache.get(query)`. Returns cache for an specific query.
+	* `this._cache.clean([query])`. Clean cache of an specific query. Cleans all caches if no query is provided.
 
 #### Example
 
@@ -34,8 +36,8 @@ import { Origin } from "@xbyorange/mercury";
 import requestPromise from "request-promise";
 
 export class Request extends Origin {
-  constructor(url, options) {
-    super(url, options.defaultValue);
+  constructor(url, options = {}) {
+    super(url, options.defaultValue, options.uuid);
     this._url = url;
   }
 

--- a/docs/selector/api.md
+++ b/docs/selector/api.md
@@ -2,74 +2,76 @@
 
 #### Constructor
 
-* `const selector = new Selector(sources, parserCallback(sourcesResults[, currentQuery]), [defaultValue])`
-  * Arguments
-    * sources - `<source object or Array of sources objects>` 
-      * source object - `<source instance, or customSourceReader object>`
-        * source instance - `<instance of an Origin or Selector>` Origin or Selector to read.
-        * customSourceReader - `<Object>` with next properties:
-          * `source`: `<instance of an Origin or Selector>` Origin or Selector to read.
-          * `query`: `<Function>` `query: (currentQuery[, previousSourcesResults])`. Query callback.
-            * Arguments:
-              * currentQuery - `<Any>` Selector current query.
-              * previousSourcesResults - `<Array of Any>` Array containing results of all previously fetched sources in series.
-            * Returns:
-              * `<Any>` Result of this callback will be passed as `query` to the source.
-          * `catch`: `<Function>` `catch: (error[, currentQuery])`.
-            * Arguments:
-              * error - `<Error>` Error thrown by the read method of the source.
-              * currentQuery  - `<Any>` Selector current query.
-            * Returns:
-              * `<Error>` - Source will throw this error.
-              * `<Any>` - Source will return this value instead of error.
-              * `<source instance>` - The `read` method of the returned source instance will be called, and returned result will be assigned as value of the current source (Allows to switch to another source if first returns an error)
-      * Array of source objects - `<Array of <source object>>` Provided sources will be fetched in parallel.
-    * parserCallback - `<Function>`
-      * Arguments:
-        * sourcesResults - `<Any>` - Results returned by the `read` method of the sources.
-        * currentQuery - `<Any>` Selector current query.
-      * Returns:
-        * Result data - `<Any>`
-        * `<Promise>` - The result of the returned Promise will be returned as result data.
-        * `<source instance>` - If another source instance is returned, it will be called with same method and data than Selector was.
-    * defaultValue - `<Any>` Default value to return until real data is returned.
+* `const selector = new Selector(source, source, parserCallback(sourcesResults[, currentQuery]), [options])`
+	* Arguments
+		* sources - `<source object or Array of sources objects>` 
+			* source object - `<source instance, or customSourceReader object>`
+				* source instance - `<instance of an Origin or Selector>` Origin or Selector to read.
+				* customSourceReader - `<Object>` with next properties:
+					* `source`: `<instance of an Origin or Selector>` Origin or Selector to read.
+					* `query`: `<Function>` `query: (currentQuery[, previousSourcesResults])`. Query callback.
+						* Arguments:
+							* currentQuery - `<Any>` Selector current query.
+							* previousSourcesResults - `<Array of Any>` Array containing results of all previously fetched sources in series.
+						* Returns:
+							* `<Any>` Result of this callback will be passed as `query` to the source.
+					* `catch`: `<Function>` `catch: (error[, currentQuery])`.
+						* Arguments:
+							* error - `<Error>` Error thrown by the read method of the source.
+							* currentQuery  - `<Any>` Selector current query.
+						* Returns:
+							* `<Error>` - Source will throw this error.
+							* `<Any>` - Source will return this value instead of error.
+							* `<source instance>` - The `read` method of the returned source instance will be called, and returned result will be assigned as value of the current source (Allows to switch to another source if first returns an error)
+			* Array of source objects - `<Array of <source object>>` Provided sources will be fetched in parallel.
+		* parserCallback - `<Function>`
+			* Arguments:
+				* sourcesResults - `<Any>` - Results returned by the `read` method of the sources.
+				* currentQuery - `<Any>` Selector current query.
+			* Returns:
+				* Result data - `<Any>`
+				* `<Promise>` - The result of the returned Promise will be returned as result data.
+				* `<source instance>` - If another source instance is returned, it will be called with same method and data than Selector was.
+		* options - `<Object>`
+			* defaultValue - `<Any>` Default value to return until real data is returned.
+			* uuid - `<String>` Custom uuid to be defined as selector "_id"
 
 #### Instance
 
 * read `selector.read()`
-  * Statics:
-    * error - `<Error>` If read method returns an error, it will be accessible at this property.
-    * loading - `<Boolean>` Will be true while Selector read is in progress.
-    * value - `<Any>` Value returned by `read` method.
-  * Returns
-    * `<Any>` - Result of the parser function.
+	* Statics:
+		* error - `<Error>` If read method returns an error, it will be accessible at this property.
+		* loading - `<Boolean>` Will be true while Selector read is in progress.
+		* value - `<Any>` Value returned by `read` method.
+	* Returns
+		* `<Any>` - Result of the parser function.
 * create, update, delete `selector.create(data)` These methods can be used only when Selector returns another source.
-  * Statics:
-    * error - `<Error>` If read method returns an error, it will be accessible at this property.
-    * loading - `<Boolean>` Will be true while Selector read is in progress.
-    * value - `<Any>` Value returned by `read` method.
-  * Arguments
-    * data - `<Any>` Data that will be passed to the correspondant create, update or delete method of the returned source.
-  * Returns
-    * `<Any>` - Result of the correspondant method of returned source.
+	* Statics:
+		* error - `<Error>` If read method returns an error, it will be accessible at this property.
+		* loading - `<Boolean>` Will be true while Selector read is in progress.
+		* value - `<Any>` Value returned by `read` method.
+	* Arguments
+		* data - `<Any>` Data that will be passed to the correspondant create, update or delete method of the returned source.
+	* Returns
+		* `<Any>` - Result of the correspondant method of returned source.
 * clean `selector.clean([query])`
-  * Arguments
-    * query - `<Any>` Any object, string, array etc. for quering the source.
-  * Returns
-    * `<undefined>` - Selector instance cache corresponding to the provided query will be cleaned.
+	* Arguments
+		* query - `<Any>` Any object, string, array etc. for quering the source.
+	* Returns
+		* `<undefined>` - Selector instance cache corresponding to the provided query will be cleaned.
 * query `selector.query([query])`
-  * Arguments
-    * query - `<Any>` Any object, string, array etc. for quering the source.
-  * Returns
-    * `<selector instance>` - Will return a selector instance unique for the query provided. Returned instances will be the same if query is the same.
+	* Arguments
+		* query - `<Any>` Any object, string, array etc. for quering the source.
+	* Returns
+		* `<selector instance>` - Will return a selector instance unique for the query provided. Returned instances will be the same if query is the same.
 * addCustomQueries `selector.addCustomQueries(customQueryObject)`
-  * Aliases
-    * addCustomQuery `selector.addCustomQuery({ queryName: queryCallback(query)})`
-  * Arguments
-    * customQueryObject - `<Object>` containing properties:
-      * [key] - `<String>` Key will be used as name of the new selector method that will execute the custom query.
-        * queryCallback - `<Function>`
-          * Arguments
-            * query - `<Any>` Query provided by the user when using custom query method.
-          * Returns
-            * currentQuery - `<Any>` Query that will be used as current query, and passed to the CRUD methods when executed.
+	* Aliases
+		* addCustomQuery `selector.addCustomQuery({ queryName: queryCallback(query)})`
+	* Arguments
+		* customQueryObject - `<Object>` containing properties:
+			* [key] - `<String>` Key will be used as name of the new selector method that will execute the custom query.
+				* queryCallback - `<Function>`
+					* Arguments
+						* query - `<Any>` Query provided by the user when using custom query method.
+					* Returns
+						* currentQuery - `<Any>` Query that will be used as current query, and passed to the CRUD methods when executed.

--- a/docs/selector/default-value.md
+++ b/docs/selector/default-value.md
@@ -1,6 +1,6 @@
 ## Default values
 
-Define a default value for the Selector as last argument. Selector `value` property will have that value until real value is ready
+Define a default value for the Selector using options in last argument. Selector `value` property will have that value until real value is ready
 
 ```js
 const booksAndAuthors = new Selector(
@@ -9,7 +9,9 @@ const booksAndAuthors = new Selector(
     books: booksAndAuthors[0],
     authors: booksAndAuthors[1]
   }),
-  []
+  {
+    defaultValue: []
+  }
 );
 console.log(booksAndAuthors.read.value); // []
 ```

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -1,4 +1,10 @@
-import { CLEAN_ANY_EVENT_NAME, queryId, cleanCacheEventName, isCacheEventName } from "./helpers";
+import {
+  CLEAN_ANY_EVENT_NAME,
+  queryId,
+  cleanCacheEventName,
+  isCacheEventName,
+  queriedUniqueId
+} from "./helpers";
 
 export class Cache {
   constructor(eventEmitter, id) {
@@ -20,7 +26,7 @@ export class Cache {
     return {
       action: "clean",
       source: {
-        _id: `${this._id}${queryUniqueId ? `-${queryUniqueId}` : ""}`,
+        _id: queriedUniqueId(this._id, queryUniqueId),
         _queryId: queryUniqueId,
         _root
       }

--- a/src/Cache.js
+++ b/src/Cache.js
@@ -3,7 +3,8 @@ import {
   queryId,
   cleanCacheEventName,
   isCacheEventName,
-  queriedUniqueId
+  queriedUniqueId,
+  isUndefined
 } from "./helpers";
 
 export class Cache {
@@ -34,14 +35,14 @@ export class Cache {
   }
 
   clean(query, _root) {
-    if (query) {
+    if (!isUndefined(query)) {
       const queryIdentifier = queryId(query);
       delete this._cachedData[queryIdentifier];
       this._eventEmitter.emit(cleanCacheEventName(query), query);
       this._eventEmitter.emit(CLEAN_ANY_EVENT_NAME, this.getAnyData(queryIdentifier, _root));
     } else {
       this._reset();
-      this._eventEmitter.emit(CLEAN_ANY_EVENT_NAME, this.getAnyData(null, _root));
+      this._eventEmitter.emit(CLEAN_ANY_EVENT_NAME, this.getAnyData(query, _root));
     }
   }
 

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -1,10 +1,12 @@
+import { isUndefined } from "./helpers";
+
 export class EventEmitter {
   constructor() {
     this.events = {};
   }
 
   _getEventListByName(eventName) {
-    if (typeof this.events[eventName] === "undefined") {
+    if (isUndefined(this.events[eventName])) {
       this.events[eventName] = new Set();
     }
     return this.events[eventName];

--- a/src/Origin.js
+++ b/src/Origin.js
@@ -10,18 +10,21 @@ import {
   CLEAN_ANY_EVENT_NAME,
   cleanCacheEventName,
   changeEventName,
+  uniqueId,
   queryId,
+  queriedUniqueId,
+  isUndefined,
   actions
 } from "./helpers";
 
 export class Origin {
-  constructor(id, defaultValue) {
+  constructor(defaultId, defaultValue, options = {}) {
     this._eventEmitter = new EventEmitter();
     this._queries = {};
-    this._id = id || "";
+
+    this._defaultValue = !isUndefined(defaultValue) ? cloneDeep(defaultValue) : defaultValue;
+    this._id = options.uuid || uniqueId(defaultId, this._defaultValue);
     this._cache = new Cache(this._eventEmitter, this._id);
-    this._defaultValue =
-      typeof defaultValue !== "undefined" ? cloneDeep(defaultValue) : defaultValue;
 
     this._customQueries = {};
     this.customQueries = {};
@@ -217,7 +220,7 @@ export class Origin {
     newQuery.onCleanAny = listener => this._onCleanAny(listener);
     newQuery.removeCleanAnyListener = listener => this._removeCleanAnyListener(listener);
     newQuery._queryId = queryUniqueId;
-    newQuery._id = `${this._id}${queryUniqueId ? `-${queryUniqueId}` : ""}`;
+    newQuery._id = queriedUniqueId(this._id, queryUniqueId);
     newQuery.actions = actions;
     newQuery._isSource = true;
     newQuery._root = this;

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -17,7 +17,7 @@ export class Selector extends Origin {
     let defaultValue;
     let options;
 
-    // Check if last argument is default value
+    // Check if last argument is default value or options
     if (!isFunction(args[lastIndex])) {
       defaultValue = args[lastIndex];
       lastIndex = args.length - 2;

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -2,18 +2,33 @@ import { once, isFunction, isArray } from "lodash";
 import isPromise from "is-promise";
 
 import { Origin } from "./Origin";
-import { READ_METHOD, CREATE_METHOD, UPDATE_METHOD, DELETE_METHOD } from "./helpers";
+import {
+  READ_METHOD,
+  CREATE_METHOD,
+  UPDATE_METHOD,
+  DELETE_METHOD,
+  seemsToBeSelectorOptions
+} from "./helpers";
 
 export class Selector extends Origin {
   constructor() {
     const args = Array.from(arguments);
     let lastIndex = args.length - 1;
     let defaultValue;
+    let options;
 
     // Check if last argument is default value
     if (!isFunction(args[lastIndex])) {
       defaultValue = args[lastIndex];
       lastIndex = args.length - 2;
+      if (seemsToBeSelectorOptions(defaultValue)) {
+        options = defaultValue;
+        defaultValue = defaultValue.defaultValue;
+      } else {
+        console.warn(
+          "Please provide an object with 'defaultValue' property. Defining default value as last argument will be deprecated in next versions"
+        );
+      }
     }
 
     const sources = args.slice(0, lastIndex);
@@ -38,7 +53,7 @@ export class Selector extends Origin {
 
     const testQueries = getTestQueries(sources);
 
-    super(`select:${sourceIds.join(":")}`, defaultValue);
+    super(`select:${sourceIds.join(":")}`, defaultValue, options);
 
     this._sources = sources;
     this._resultsParser = args[lastIndex];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,8 +63,11 @@ export const uniqueId = (id, defaultValue) => hash(`${id}${JSON.stringify(defaul
 export const queriedUniqueId = (uniqueId, queryUniqueId) => dashJoin([uniqueId, queryUniqueId]);
 
 export const seemsToBeSelectorOptions = defaultValueOrOptions => {
-  if (isUndefined(defaultValueOrOptions)) {
+  if (!defaultValueOrOptions) {
     return false;
   }
-  return !!defaultValueOrOptions.defaultValue || !!defaultValueOrOptions.uuid;
+  return (
+    defaultValueOrOptions.hasOwnProperty("defaultValue") ||
+    defaultValueOrOptions.hasOwnProperty("uuid")
+  );
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,8 +16,6 @@ export const VALID_METHODS = [CREATE_METHOD, READ_METHOD, UPDATE_METHOD, DELETE_
 export const CHANGE_ANY_EVENT_NAME = `${CHANGE_EVENT_PREFIX}${ANY_SUFIX}`;
 export const CLEAN_ANY_EVENT_NAME = `${CACHE_EVENT_PREFIX}${ANY_SUFIX}`;
 
-export const queryId = query => JSON.stringify(query);
-
 export const isCacheEventName = eventName =>
   eventName.indexOf(CACHE_EVENT_PREFIX) === 0 && eventName !== CLEAN_ANY_EVENT_NAME;
 
@@ -47,8 +45,6 @@ export const actions = {
   }
 };
 
-const dashJoin = arr => arr.join("-");
-
 export const hash = str => {
   return `${str.split("").reduce((a, b) => {
     a = (a << 5) - a + b.charCodeAt(0);
@@ -57,6 +53,10 @@ export const hash = str => {
 };
 
 export const isUndefined = variable => typeof variable === "undefined";
+
+export const queryId = query => (isUndefined(query) ? query : `(${JSON.stringify(query)})`);
+
+export const dashJoin = arr => arr.filter(val => !isUndefined(val)).join("-");
 
 export const uniqueId = (id, defaultValue) => hash(`${id}${JSON.stringify(defaultValue)}`);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,3 +46,25 @@ export const actions = {
     error: `${DELETE_METHOD}${ERROR}`
   }
 };
+
+const dashJoin = arr => arr.join("-");
+
+export const hash = str => {
+  return `${str.split("").reduce((a, b) => {
+    a = (a << 5) - a + b.charCodeAt(0);
+    return a & a;
+  }, 0)}`;
+};
+
+export const isUndefined = variable => typeof variable === "undefined";
+
+export const uniqueId = (id, defaultValue) => hash(`${id}${JSON.stringify(defaultValue)}`);
+
+export const queriedUniqueId = (uniqueId, queryUniqueId) => dashJoin([uniqueId, queryUniqueId]);
+
+export const seemsToBeSelectorOptions = defaultValueOrOptions => {
+  if (isUndefined(defaultValueOrOptions)) {
+    return false;
+  }
+  return !!defaultValueOrOptions.defaultValue || !!defaultValueOrOptions.uuid;
+};

--- a/test/Origin.events.js
+++ b/test/Origin.events.js
@@ -119,7 +119,7 @@ test.describe("Origin events", () => {
         return Promise.all([
           test.expect(eventData.action).to.equal("clean"),
           test.expect(eventData.source._id).to.equal(testOrigin._id),
-          test.expect(eventData.source._queryId).to.equal(null),
+          test.expect(eventData.source._queryId).to.equal(undefined),
           test.expect(eventData.source._root).to.equal(testOrigin)
         ]);
       });
@@ -233,7 +233,7 @@ test.describe("Origin events", () => {
         return Promise.all([
           test.expect(eventData.action).to.equal("clean"),
           test.expect(eventData.source._id).to.equal(queriedOrigin._id),
-          test.expect(eventData.source._queryId).to.equal(JSON.stringify(FOO_QUERY)),
+          test.expect(eventData.source._queryId).to.equal(`(${JSON.stringify(FOO_QUERY)})`),
           test.expect(eventData.source._root).to.equal(testOrigin)
         ]);
       });

--- a/test/Origin.id.js
+++ b/test/Origin.id.js
@@ -1,13 +1,19 @@
 const test = require("mocha-sinon-chai");
 
 const { Origin } = require("../src/Origin");
+const helpers = require("../src/helpers");
 
 test.describe("Origin id", () => {
   const FOO_ID = "foo-id";
+  const FOO_UUID = "foo-uuid";
+  const FOO_CUSTOM_UUID = "foo-custom-uuid";
+  const TestOrigin = class extends Origin {};
   let sandbox;
 
   test.beforeEach(() => {
     sandbox = test.sinon.createSandbox();
+    sandbox.stub(helpers, "uniqueId").returns(FOO_UUID);
+    sandbox.stub(helpers, "queriedUniqueId").returns("foo-query-uuid");
   });
 
   test.afterEach(() => {
@@ -15,10 +21,25 @@ test.describe("Origin id", () => {
   });
 
   test.describe("Without query", () => {
-    test.it("private property _id should be equal to given id", () => {
-      const TestOrigin = class extends Origin {};
-      const testOrigin = new TestOrigin("foo-id");
-      test.expect(testOrigin._id).to.equal(FOO_ID);
+    test.it("private property _id should be calculated based on default id", () => {
+      new TestOrigin(FOO_ID);
+      test.expect(helpers.uniqueId).to.have.been.calledWith(FOO_ID, undefined);
+    });
+
+    test.it(
+      "private property _id should be calculated based on default id and default value",
+      () => {
+        const fooDefaultValue = "foo-default-value";
+        new TestOrigin(FOO_ID, fooDefaultValue);
+        test.expect(helpers.uniqueId).to.have.been.calledWith(FOO_ID, fooDefaultValue);
+      }
+    );
+
+    test.it("private property _id should be custom uuid if provided", () => {
+      const testOrigin = new TestOrigin(FOO_ID, undefined, {
+        uuid: FOO_CUSTOM_UUID
+      });
+      test.expect(testOrigin._id).to.equal(FOO_CUSTOM_UUID);
     });
   });
 
@@ -26,11 +47,40 @@ test.describe("Origin id", () => {
     test.it(
       "private property _id should be equal to the combination of given id and the queryId",
       () => {
-        const TestOrigin = class extends Origin {};
-        const testOrigin = new TestOrigin("foo-id").query({
+        new TestOrigin("foo-id").query({
           foo: "foo-query"
         });
-        test.expect(testOrigin._id).to.equal(`${FOO_ID}-{"foo":"foo-query"}`);
+        test
+          .expect(helpers.queriedUniqueId)
+          .to.have.been.calledWith(FOO_UUID, '({"foo":"foo-query"})');
+      }
+    );
+
+    test.it(
+      "private property _id should be calculated using custom uuid if provided and the queryId",
+      () => {
+        new TestOrigin(FOO_ID, undefined, {
+          uuid: FOO_CUSTOM_UUID
+        }).query({
+          foo: "foo-query"
+        });
+        test
+          .expect(helpers.queriedUniqueId)
+          .to.have.been.calledWith(FOO_CUSTOM_UUID, '({"foo":"foo-query"})');
+      }
+    );
+
+    test.it(
+      "private property _id should be calculated using custom uuid if provided and the queryId, ignoring default value",
+      () => {
+        new TestOrigin(FOO_ID, "foo-default-value", {
+          uuid: FOO_CUSTOM_UUID
+        }).query({
+          foo: "foo-query"
+        });
+        test
+          .expect(helpers.queriedUniqueId)
+          .to.have.been.calledWith(FOO_CUSTOM_UUID, '({"foo":"foo-query"})');
       }
     );
   });
@@ -39,15 +89,34 @@ test.describe("Origin id", () => {
     test.it(
       "private property _id should be equal to the combination of given id and the extension of the queries ids",
       () => {
-        const TestOrigin = class extends Origin {};
-        const testOrigin = new TestOrigin("foo-id")
+        new TestOrigin("foo-id")
           .query({
             foo: "foo-query"
           })
           .query({
             foo2: "foo-query-2"
           });
-        test.expect(testOrigin._id).to.equal(`${FOO_ID}-{"foo":"foo-query","foo2":"foo-query-2"}`);
+        test
+          .expect(helpers.queriedUniqueId)
+          .to.have.been.calledWith(FOO_UUID, '({"foo":"foo-query","foo2":"foo-query-2"})');
+      }
+    );
+
+    test.it(
+      "private property _id should be custom uuid if provided and the extension of the queries ids",
+      () => {
+        new TestOrigin(FOO_ID, undefined, {
+          uuid: FOO_CUSTOM_UUID
+        })
+          .query({
+            foo: "foo-query"
+          })
+          .query({
+            foo2: "foo-query-2"
+          });
+        test
+          .expect(helpers.queriedUniqueId)
+          .to.have.been.calledWith(FOO_CUSTOM_UUID, '({"foo":"foo-query","foo2":"foo-query-2"})');
       }
     );
   });

--- a/test/Selector.cache.js
+++ b/test/Selector.cache.js
@@ -3,7 +3,7 @@ const test = require("mocha-sinon-chai");
 const { Origin } = require("../src/Origin");
 const { Selector } = require("../src/Selector");
 
-test.describe("Selector value", () => {
+test.describe("Selector cache", () => {
   const FOO_ORIGIN_VALUE = {
     foo: "foo"
   };

--- a/test/Selector.defaultValue.js
+++ b/test/Selector.defaultValue.js
@@ -19,15 +19,27 @@ test.describe("Selector defaultValue", () => {
       }
     };
     testOrigin = new TestOrigin();
-    testSelector = new Selector(testOrigin, originResult => originResult, DEFAULT_VALUE);
   });
 
   test.afterEach(() => {
     sandbox.restore();
   });
 
-  test.describe("when Origin has defaultValue defined", () => {
+  test.describe("when has defaultValue defined in deprecated way", () => {
     test.it("should return defaultValue until real value is returned", () => {
+      testSelector = new Selector(testOrigin, originResult => originResult, DEFAULT_VALUE);
+      test.expect(testSelector.read.value).to.equal(DEFAULT_VALUE);
+      return testSelector.read().then(() => {
+        return test.expect(testSelector.read.value).to.equal(VALUE);
+      });
+    });
+  });
+
+  test.describe("when has defaultValue defined", () => {
+    test.it("should return defaultValue until real value is returned", () => {
+      testSelector = new Selector(testOrigin, originResult => originResult, {
+        defaultValue: DEFAULT_VALUE
+      });
       test.expect(testSelector.read.value).to.equal(DEFAULT_VALUE);
       return testSelector.read().then(() => {
         return test.expect(testSelector.read.value).to.equal(VALUE);

--- a/test/Selector.events.js
+++ b/test/Selector.events.js
@@ -122,7 +122,7 @@ test.describe("Selector events", () => {
         return Promise.all([
           test.expect(eventData.action).to.equal("clean"),
           test.expect(eventData.source._id).to.equal(testSelector._id),
-          test.expect(eventData.source._queryId).to.equal(null),
+          test.expect(eventData.source._queryId).to.equal(undefined),
           test.expect(eventData.source._root).to.equal(testSelector)
         ]);
       });
@@ -236,7 +236,7 @@ test.describe("Selector events", () => {
         return Promise.all([
           test.expect(eventData.action).to.equal("clean"),
           test.expect(eventData.source._id).to.equal(queriedSelector._id),
-          test.expect(eventData.source._queryId).to.equal(JSON.stringify(FOO_QUERY)),
+          test.expect(eventData.source._queryId).to.equal(`(${JSON.stringify(FOO_QUERY)})`),
           test.expect(eventData.source._root).to.equal(testSelector)
         ]);
       });

--- a/test/Selector.id.js
+++ b/test/Selector.id.js
@@ -44,8 +44,15 @@ test.describe("Selector id", () => {
       }
     );
 
+    test.it("private property _id should be equal to custom uuid", () => {
+      testSelector = new Selector(testOrigin, testOrigin2, originResult => originResult, {
+        uuid: FOO_CUSTOM_UUID
+      });
+      test.expect(testSelector._id).to.equal(FOO_CUSTOM_UUID);
+    });
+
     test.it(
-      "private property _id should be calculated using sources ids adding 'select:' prefix",
+      "private property _id should be calculated using sources ids adding 'select:' prefix and default value when provided in deprecated way",
       () => {
         testSelector = new Selector(
           testOrigin,
@@ -59,12 +66,17 @@ test.describe("Selector id", () => {
       }
     );
 
-    test.it("private property _id should be equal to custom uuid", () => {
-      testSelector = new Selector(testOrigin, testOrigin2, originResult => originResult, {
-        uuid: FOO_CUSTOM_UUID
-      });
-      test.expect(testSelector._id).to.equal(FOO_CUSTOM_UUID);
-    });
+    test.it(
+      "private property _id should be calculated using sources ids adding 'select:' prefix and default value",
+      () => {
+        testSelector = new Selector(testOrigin, testOrigin2, originResult => originResult, {
+          defaultValue: "foo-default-value"
+        });
+        test
+          .expect(helpers.uniqueId)
+          .to.have.been.calledWith(`select:${FOO_UUID}:${FOO_UUID}`, "foo-default-value");
+      }
+    );
   });
 
   test.describe("with query", () => {

--- a/test/Selector.id.js
+++ b/test/Selector.id.js
@@ -2,11 +2,14 @@ const test = require("mocha-sinon-chai");
 
 const { Origin } = require("../src/Origin");
 const { Selector } = require("../src/Selector");
+const helpers = require("../src/helpers");
 
 test.describe("Selector id", () => {
   const FOO_ID = "foo-origin-id";
   const FOO_ID_2 = "foo-origin-2";
   const FOO_ID_3 = "foo-origin-3";
+  const FOO_UUID = "foo-uuid";
+  const FOO_CUSTOM_UUID = "foo-custom-uuid";
   let sandbox;
   let TestOrigin;
   let testOrigin;
@@ -16,6 +19,8 @@ test.describe("Selector id", () => {
 
   test.beforeEach(() => {
     sandbox = test.sinon.createSandbox();
+    sandbox.stub(helpers, "uniqueId").returns(FOO_UUID);
+    sandbox.stub(helpers, "queriedUniqueId").returns("foo-query-uuid");
     TestOrigin = class extends Origin {
       _read() {
         return Promise.resolve();
@@ -32,23 +37,57 @@ test.describe("Selector id", () => {
   });
 
   test.describe("without query", () => {
-    test.it("private property _id should be equal to sources ids adding 'select:' prefix", () => {
-      test.expect(testSelector._id).to.equal(`select:${FOO_ID}`);
+    test.it(
+      "private property _id should be calculated using source id adding 'select:' prefix",
+      () => {
+        test.expect(helpers.uniqueId).to.have.been.calledWith(`select:${FOO_UUID}`, undefined);
+      }
+    );
+
+    test.it(
+      "private property _id should be calculated using sources ids adding 'select:' prefix",
+      () => {
+        testSelector = new Selector(
+          testOrigin,
+          testOrigin2,
+          originResult => originResult,
+          "foo-default-value"
+        );
+        test
+          .expect(helpers.uniqueId)
+          .to.have.been.calledWith(`select:${FOO_UUID}:${FOO_UUID}`, "foo-default-value");
+      }
+    );
+
+    test.it("private property _id should be equal to custom uuid", () => {
+      testSelector = new Selector(testOrigin, testOrigin2, originResult => originResult, {
+        uuid: FOO_CUSTOM_UUID
+      });
+      test.expect(testSelector._id).to.equal(FOO_CUSTOM_UUID);
     });
   });
 
   test.describe("with query", () => {
     test.it(
-      "private property _id should be equal to sources ids adding 'select:' prefix and the query id",
+      "private property _id should be calculated using sources ids adding 'select:' prefix and the query id",
       () => {
-        test.expect(testSelector.query("foo")._id).to.equal(`select:${FOO_ID}-"foo"`);
+        testSelector.query("foo");
+        test.expect(helpers.queriedUniqueId).to.have.been.calledWith(FOO_UUID, '("foo")');
       }
     );
+
+    test.it("private property _id should be calculated using custom id and the query id", () => {
+      testSelector = new Selector(testOrigin, originResult => originResult, {
+        uuid: FOO_CUSTOM_UUID
+      });
+      testSelector.query("foo");
+      test.expect(helpers.queriedUniqueId).to.have.been.calledWith(FOO_CUSTOM_UUID, '("foo")');
+    });
   });
 
   test.describe("when sources are queryied", () => {
     test.it(
-      "private property _id should be equal to sources ids adding 'select:' prefix and the query id",
+      "private property _id of queried resources should be calculated using sources ids and the query id",
       () => {
         testSelector = new Selector(
           {
@@ -56,22 +95,47 @@ test.describe("Selector id", () => {
             query: query => query
           },
           originResult => originResult
-        );
-        test.expect(testSelector._id).to.equal(`select:${FOO_ID}`);
+        ).query("foo");
+        test.expect(helpers.queriedUniqueId).to.have.been.calledWith(FOO_UUID, '("foo")');
       }
     );
+
+    test.it("private property _id should be calculated using custom uuid and the query id", () => {
+      testSelector = new Selector(
+        {
+          source: testOrigin,
+          query: query => query
+        },
+        originResult => originResult,
+        {
+          uuid: FOO_CUSTOM_UUID
+        }
+      ).query("foo");
+      test.expect(helpers.queriedUniqueId).to.have.been.calledWith(FOO_CUSTOM_UUID, '("foo")');
+    });
   });
 
   test.describe("when sources are concurrent", () => {
     test.it(
       "private property _id should be equal to sources ids adding 'select:' prefix and the query id",
       () => {
+        testOrigin = new TestOrigin(FOO_ID, undefined, {
+          uuid: FOO_ID
+        });
+        testOrigin2 = new TestOrigin(FOO_ID_2, undefined, {
+          uuid: FOO_ID_2
+        });
+        testOrigin3 = new TestOrigin(FOO_ID_3, undefined, {
+          uuid: FOO_ID_3
+        });
         testSelector = new Selector(
           [testOrigin3, testOrigin2],
           testOrigin,
           originResult => originResult
         );
-        test.expect(testSelector._id).to.equal(`select:${FOO_ID_3}:${FOO_ID_2}:${FOO_ID}`);
+        test
+          .expect(helpers.uniqueId)
+          .to.have.been.calledWith(`select:${FOO_ID_3}:${FOO_ID_2}:${FOO_ID}`, undefined);
       }
     );
   });
@@ -80,6 +144,15 @@ test.describe("Selector id", () => {
     test.it(
       "private property _id should be equal to sources ids adding 'select:' prefix and the query id",
       () => {
+        testOrigin = new TestOrigin(FOO_ID, undefined, {
+          uuid: FOO_ID
+        });
+        testOrigin2 = new TestOrigin(FOO_ID_2, undefined, {
+          uuid: FOO_ID_2
+        });
+        testOrigin3 = new TestOrigin(FOO_ID_3, undefined, {
+          uuid: FOO_ID_3
+        });
         testSelector = new Selector(
           testOrigin3,
           [
@@ -94,7 +167,9 @@ test.describe("Selector id", () => {
           ],
           originResult => originResult
         );
-        test.expect(testSelector._id).to.equal(`select:${FOO_ID_3}:${FOO_ID}:${FOO_ID_2}`);
+        test
+          .expect(helpers.uniqueId)
+          .to.have.been.calledWith(`select:${FOO_ID_3}:${FOO_ID}:${FOO_ID_2}`, undefined);
       }
     );
   });
@@ -122,7 +197,7 @@ test.describe("Selector id", () => {
           },
           originResult => originResult
         );
-        test.expect(testSelector._id).to.equal(`select:select:foo-origin-id`);
+        test.expect(helpers.uniqueId).to.have.been.calledWith(`select:${FOO_UUID}`, undefined);
       }
     );
 
@@ -135,8 +210,8 @@ test.describe("Selector id", () => {
             query: query => query
           },
           originResult => originResult
-        );
-        test.expect(testSelector.query("foo")._id).to.equal(`select:select:foo-origin-id-"foo"`);
+        ).query("foo");
+        test.expect(helpers.queriedUniqueId).to.have.been.calledWith(FOO_UUID, '("foo")');
       }
     );
   });

--- a/test/Selector.parallel.deprecated.js
+++ b/test/Selector.parallel.deprecated.js
@@ -3,7 +3,7 @@ const test = require("mocha-sinon-chai");
 const { Origin } = require("../src/Origin");
 const { Selector } = require("../src/Selector");
 
-test.describe("Selector using parallel sources", () => {
+test.describe("Selector using parallel sources defining default value in deprecated way", () => {
   const FORCE_ERROR = "force-error";
   const FOO_ORIGIN_VALUE = {
     foo: "foo"
@@ -124,9 +124,7 @@ test.describe("Selector using parallel sources", () => {
           spies.testSelectorRead();
           return originResults;
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -178,9 +176,7 @@ test.describe("Selector using parallel sources", () => {
           spies.testSelectorRead();
           return originResults;
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -211,9 +207,7 @@ test.describe("Selector using parallel sources", () => {
           spies.testSelectorRead();
           return originResults;
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -275,9 +269,7 @@ test.describe("Selector using parallel sources", () => {
           spies.testSelectorRead();
           return originResults;
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -349,9 +341,7 @@ test.describe("Selector using parallel sources", () => {
           parallel: parallelResults,
           single: origin3Results
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -403,9 +393,7 @@ test.describe("Selector using parallel sources", () => {
           parallel: parallelResults,
           single: origin3Results
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -423,9 +411,11 @@ test.describe("Selector using parallel sources", () => {
 
   test.describe("with chained parallel requests", () => {
     test.beforeEach(() => {
-      testSelector = new Selector([testOrigin, [testOrigin2, testOrigin3]], results => results, {
-        defaultValue: DEFAULT_VALUE
-      });
+      testSelector = new Selector(
+        [testOrigin, [testOrigin2, testOrigin3]],
+        results => results,
+        DEFAULT_VALUE
+      );
     });
 
     test.it("should return value returned by parser function", () => {
@@ -461,9 +451,7 @@ test.describe("Selector using parallel sources", () => {
               single: origin3Results
             };
           },
-          {
-            defaultValue: DEFAULT_VALUE
-          }
+          DEFAULT_VALUE
         );
       });
 
@@ -558,9 +546,7 @@ test.describe("Selector using parallel sources", () => {
               single: origin3Results
             };
           },
-          {
-            defaultValue: DEFAULT_VALUE
-          }
+          DEFAULT_VALUE
         );
       });
 

--- a/test/Selector.parallel.js
+++ b/test/Selector.parallel.js
@@ -3,7 +3,7 @@ const test = require("mocha-sinon-chai");
 const { Origin } = require("../src/Origin");
 const { Selector } = require("../src/Selector");
 
-test.describe("Selector value", () => {
+test.describe("Selector using parallel sources", () => {
   const FORCE_ERROR = "force-error";
   const FOO_ORIGIN_VALUE = {
     foo: "foo"

--- a/test/Selector.value.deprecated.js
+++ b/test/Selector.value.deprecated.js
@@ -3,7 +3,7 @@ const test = require("mocha-sinon-chai");
 const { Origin } = require("../src/Origin");
 const { Selector } = require("../src/Selector");
 
-test.describe("Selector value", () => {
+test.describe("Selector value defining default value in deprecated way", () => {
   const FOO_ORIGIN_VALUE = {
     foo: "foo"
   };
@@ -75,9 +75,7 @@ test.describe("Selector value", () => {
           ...originResult,
           ...origin2Result
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -105,9 +103,7 @@ test.describe("Selector value", () => {
           ...originResult,
           ...origin2Result
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -136,9 +132,7 @@ test.describe("Selector value", () => {
           ...originResult,
           ...origin2Result
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -198,9 +192,7 @@ test.describe("Selector value", () => {
           ...origin2Result,
           ...selectorResult
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -261,9 +253,7 @@ test.describe("Selector value", () => {
           ...originResult,
           ...origin2Result
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -296,9 +286,7 @@ test.describe("Selector value", () => {
           ...originResult,
           ...origin2Result
         }),
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -334,9 +322,7 @@ test.describe("Selector value", () => {
             }, 50);
           });
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -358,9 +344,7 @@ test.describe("Selector value", () => {
         (originResult, origin2Result, query) => {
           return testOrigin3.query(query);
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 
@@ -381,9 +365,7 @@ test.describe("Selector value", () => {
         () => {
           return testOriginSelector;
         },
-        {
-          defaultValue: DEFAULT_VALUE
-        }
+        DEFAULT_VALUE
       );
     });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,33 @@
+const test = require("mocha-sinon-chai");
+
+const helpers = require("../src/helpers");
+
+test.describe("helpers", () => {
+  test.describe("hash method", () => {
+    test.it("should return a unique identifier based on provided string", () => {
+      test.expect(helpers.hash("foo")).to.equal("101574");
+    });
+
+    test.it("should return alwys same identifier if same string is provided", () => {
+      test.expect(helpers.hash("foo-string")).to.equal(helpers.hash("foo-string"));
+    });
+
+    test.it("should return different identifier if different strings are provided", () => {
+      test.expect(helpers.hash("foo-1")).to.not.equal(helpers.hash("foo-2"));
+    });
+  });
+
+  test.describe("uniqueId method", () => {
+    test.it("should return the hash of provided id and stringified defaultValue", () => {
+      test
+        .expect(helpers.uniqueId("foo", { foo: "foo" }))
+        .to.equal(helpers.hash('foo{"foo":"foo"}'));
+    });
+  });
+
+  test.describe("queriedUniqueId method", () => {
+    test.it("should return concated provided id and query id", () => {
+      test.expect(helpers.queriedUniqueId("foo", "foo2")).to.equal("foo-foo2");
+    });
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -30,4 +30,41 @@ test.describe("helpers", () => {
       test.expect(helpers.queriedUniqueId("foo", "foo2")).to.equal("foo-foo2");
     });
   });
+
+  test.describe("seemsToBeSelectorOptions method", () => {
+    test.it("should return false if receives undefined", () => {
+      test.expect(helpers.seemsToBeSelectorOptions()).to.equal(false);
+    });
+
+    test.it("should return false if receives null", () => {
+      test.expect(helpers.seemsToBeSelectorOptions(null)).to.equal(false);
+    });
+
+    test.it("should return false if receives and array", () => {
+      test.expect(helpers.seemsToBeSelectorOptions([])).to.equal(false);
+    });
+
+    test.it("should return false if receives and string", () => {
+      test.expect(helpers.seemsToBeSelectorOptions("foo")).to.equal(false);
+    });
+
+    test.it("should return false if receives and object", () => {
+      test.expect(helpers.seemsToBeSelectorOptions({})).to.equal(false);
+    });
+
+    test.it(
+      "should return true if receives and object with 'defaultValue' property, even when has false value",
+      () => {
+        test.expect(helpers.seemsToBeSelectorOptions({ defaultValue: false })).to.equal(true);
+      }
+    );
+
+    test.it("should return true if receives and object with 'defaultValue' property", () => {
+      test.expect(helpers.seemsToBeSelectorOptions({ defaultValue: [] })).to.equal(true);
+    });
+
+    test.it("should return true if receives and object with 'uuid' property", () => {
+      test.expect(helpers.seemsToBeSelectorOptions({ uuid: "foo" })).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
### [TO BE DEPRECATED]
- Last argument of Selectors will stop being assigned as "defaultValue". To define default value, it will be mandatory to pass an options object as last argument, containing a "defaultValue" property. Meanwhile, unit tests have been duplicated, and now are being executed with both implementations in order to ensure retrocompatibility.

### Added
- Accept options object in Origin constructor as last argument.
- Assign to the `_id` private property the value received in new option "uuid", when received.
- Last argument in Selectors now can be an object containing "defaultValue" and/or "uuid" options.

### Changed
- `_id` private property now is a hash of default id and default value (if no "uuid" option is received)
- Objects without query now will emit "undefined" as "_queryId" property in "cleanAny" events, instead of "null".

closes #17 