### PR TITLE
Default value callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Last argument of Selectors will stop being assigned as "defaultValue". To define default value, it will be mandatory to pass an options object as last argument, containing a "defaultValue" property.
 
 ## [1.3.0] - 2019-10-10
-
+### Added
+- defaultValue argument in Origin Constructor now can be a function. It will be called to obtain the defaultValue, passing to it the current query as argument.
 
 ## [1.2.0] - 2019-10-03
 ### Added

--- a/docs/origin/api.md
+++ b/docs/origin/api.md
@@ -9,11 +9,11 @@ If you don't define one of this methods, the correspondant CRUD method will not 
 Call `super` from your own constructor, passing:
 * `super([id, defaultValue, options])`
 	* Arguments:
-		* `defaultId` Used for debugging purposes. The `_id` of the resultant source will be a hash calculated using this default id and default value.
-		* `defaultValue` Resultant origin will have this value in the `value` property until data is fetched.
-		* `options` Object containing another options, such as:
-			* `uuid` If provided, the resultant instance will have this property as `_id`. It will not be "hashed".
-			* `tags` Tags to be assigned to the instance when created. Tags are used by "sources" handler. For further info [read the `sources` documentation](../sources/api.md).
+		* `defaultId` - `<String>` Used for debugging purposes. The `_id` of the resultant source will be a hash calculated using this default id and default value (only in case it is not a callback).
+		* `defaultValue` - `<Any>` Resultant origin will have this value in the `value` property until data is fetched. If a `<Function>` is provided, it will be executed to obtain the default value, passing the current `query` as argument.
+		* `options` - `<Object>` Object containing another options, such as:
+			* `uuid` - `<String>` If provided, the resultant instance will have this property as `_id`. It will not be "hashed".
+			* `tags` - `<String> or <Array of Strings>` Tags to be assigned to the instance when created. Tags are used by "sources" handler. For further info [read the `sources` documentation](../sources/api.md).
 
 Crud methods will receive two arguments:
 

--- a/src/Origin.js
+++ b/src/Origin.js
@@ -1,5 +1,4 @@
 import { isEqual, cloneDeep, merge, isFunction } from "lodash";
-import { mergeCloned } from "./helpers";
 
 import { Cache } from "./Cache";
 import { EventEmitter } from "./EventEmitter";
@@ -17,7 +16,8 @@ import {
   ensureArray,
   removeFalsy,
   queriedUniqueId,
-  isUndefined
+  isUndefined,
+  mergeCloned
 } from "./helpers";
 
 let automaticIdCounter = 0;

--- a/src/Origin.js
+++ b/src/Origin.js
@@ -32,7 +32,10 @@ export class Origin {
     this._eventEmitter = new EventEmitter();
     this._queries = {};
 
-    this._defaultValue = !isUndefined(defaultValue) ? cloneDeep(defaultValue) : defaultValue;
+    this._defaultValue =
+      !isUndefined(defaultValue) && !isFunction(defaultValue)
+        ? cloneDeep(defaultValue)
+        : defaultValue;
     this._id = options.uuid || uniqueId(defaultId || getAutomaticId(), this._defaultValue);
     this._cache = new Cache(this._eventEmitter, this._id);
 

--- a/src/Origin.js
+++ b/src/Origin.js
@@ -1,4 +1,4 @@
-import { isEqual, cloneDeep, merge } from "lodash";
+import { isEqual, cloneDeep, merge, isFunction } from "lodash";
 import { mergeCloned } from "./helpers";
 
 import { Cache } from "./Cache";
@@ -178,7 +178,12 @@ export class Origin {
 
         methods[methodName] = dispatchMethod;
         methods[methodName].dispatch = dispatchMethod;
-        methods[methodName].value = methodName === READ_METHOD ? this._defaultValue : undefined;
+        methods[methodName].value =
+          methodName === READ_METHOD
+            ? isFunction(this._defaultValue)
+              ? this._defaultValue(query)
+              : this._defaultValue
+            : undefined;
         methods[methodName].error = null;
         methods[methodName].loading = false;
         methods[methodName]._source = methods;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-import { cloneDeep, merge } from "lodash";
+import { cloneDeep, merge, isFunction } from "lodash";
 
 const CACHE_EVENT_PREFIX = "clean-cache-";
 const CHANGE_EVENT_PREFIX = "change-";
@@ -64,7 +64,8 @@ export const queryId = query => (isUndefined(query) ? query : `(${JSON.stringify
 
 export const dashJoin = arr => arr.filter(val => !isUndefined(val)).join("-");
 
-export const uniqueId = (id, defaultValue) => hash(`${id}${JSON.stringify(defaultValue)}`);
+export const uniqueId = (id, defaultValue) =>
+  hash(`${id}${isFunction(defaultValue) ? "" : JSON.stringify(defaultValue)}`);
 
 export const queriedUniqueId = (uuid, queryUniqueId) => dashJoin([uuid, queryUniqueId]);
 

--- a/test/Origin.defaultValueCallback.js
+++ b/test/Origin.defaultValueCallback.js
@@ -1,0 +1,96 @@
+const test = require("mocha-sinon-chai");
+
+const { Origin, sources } = require("../src/Origin");
+
+test.describe("Origin defaultValue as callback", () => {
+  let sandbox;
+
+  test.beforeEach(() => {
+    sandbox = test.sinon.createSandbox();
+  });
+
+  test.afterEach(() => {
+    sandbox.restore();
+    sources.clear();
+  });
+
+  test.describe("when Origin has defaultValue callback defined", () => {
+    test.describe("read method", () => {
+      test.describe("without query", () => {
+        test.it(
+          "should return the result of defaultValue callback until real value is returned",
+          () => {
+            const TestOrigin = class extends Origin {
+              constructor(id, defaultValue, options) {
+                const getDefaultValue = defaultValue => {
+                  return defaultValue + 2;
+                };
+                super(id, getDefaultValue, options);
+              }
+
+              _read() {
+                return Promise.resolve(5);
+              }
+            };
+            const testOrigin = new TestOrigin("", 4);
+            test.expect(testOrigin.read.value).to.equal(6);
+            return testOrigin.read().then(() => {
+              return test.expect(testOrigin.read.value).to.equal(5);
+            });
+          }
+        );
+      });
+
+      test.describe("with query", () => {
+        const QUERY = "foo-query";
+        const TestOrigin = class extends Origin {
+          constructor(id, defaultValue, options) {
+            const getDefaultValue = query => {
+              return query;
+            };
+            super(id, getDefaultValue, options);
+          }
+
+          _read() {
+            return Promise.resolve("foo-result");
+          }
+        };
+
+        test.describe("with simple query", () => {
+          test.it(
+            "should pass query to defaultValue callback, and return the result until real value is returned",
+            () => {
+              const testOrigin = new TestOrigin("", 4).query(QUERY);
+              test.expect(testOrigin.read.value).to.equal("foo-query");
+              return testOrigin.read().then(() => {
+                return test.expect(testOrigin.read.value).to.equal("foo-result");
+              });
+            }
+          );
+        });
+
+        test.describe("with chained query", () => {
+          test.it(
+            "should pass chained query to defaultValue callback, and return the result until real value is returned",
+            () => {
+              const testOrigin = new TestOrigin("", 4)
+                .query({
+                  foo: "foo"
+                })
+                .query({
+                  foo2: "foo2"
+                });
+              test.expect(testOrigin.read.value).to.deep.equal({
+                foo: "foo",
+                foo2: "foo2"
+              });
+              return testOrigin.read().then(() => {
+                return test.expect(testOrigin.read.value).to.equal("foo-result");
+              });
+            }
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/Origin.defaultValueCallback.js
+++ b/test/Origin.defaultValueCallback.js
@@ -22,7 +22,7 @@ test.describe("Origin defaultValue as callback", () => {
           () => {
             const TestOrigin = class extends Origin {
               constructor(id, defaultValue, options) {
-                const getDefaultValue = defaultValue => {
+                const getDefaultValue = () => {
                   return defaultValue + 2;
                 };
                 super(id, getDefaultValue, options);


### PR DESCRIPTION
- defaultValue argument in Origin Constructor now can be a function. It will be called to obtain the defaultValue, passing to it the current query as argument.

closes #5 