### PR TITLE
V1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Last argument of Selectors will stop being assigned as "defaultValue". To define default value, it will be mandatory to pass an options object as last argument, containing a "defaultValue" property.
 
 ## [1.4.0] - 2019-10-14
+### Added
+- Selectors can now return an array of sources.
+- Selectors can now return sources defined as objects containing `query` and/or `catch` property.
+
+### Fixed
+- Fix Sonar code smell.
 
 ## [1.3.0] - 2019-10-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [TO BE DEPRECATED]
 - Last argument of Selectors will stop being assigned as "defaultValue". To define default value, it will be mandatory to pass an options object as last argument, containing a "defaultValue" property.
 
+## [1.4.0] - 2019-10-11
+
 ## [1.3.0] - 2019-10-10
 
 ## [1.2.0] - 2019-10-10

--- a/docs/selector/selectors-returning-sources.md
+++ b/docs/selector/selectors-returning-sources.md
@@ -1,8 +1,8 @@
 ## Selectors returning another source
 
-Selectors can return another source. Then, the returned source will be called with same method and parameters than the Selector was.
+Selectors can return another source or array of sources. Then, the returned sources will be called with same method and parameters than the Selector was.
 
-Cache listeners will be added too to this returned Selector, so, if returned source cache is cleaned, the Selector cache will be cleaned too.
+Cache listeners will be added too to this returned Selector, so, if any of the returned sources cache is cleaned, the Selector cache will be cleaned too.
 
 ```js
 
@@ -49,3 +49,73 @@ await bookDetails.query("foo-id").update({
 });
 
 ```
+
+Selectors can return an array of sources:
+
+```js
+
+import { Api } from "@xbyorange/mercury-api";
+
+import { authorsOrigin } from "./authors";
+import { booksOrigin } from "./books";
+
+const authorBooksData = new Selector(
+  {
+    source: authorsOrigin,
+    query: queriedId => ({
+      urlParams: {
+        id: queriedId
+      }
+    })
+  },
+  authorDetails => {
+    return authorDetails.booksIds.map(bookId => booksOrigin.query({
+      urlParams: {
+        id: bookId
+      }
+    }))
+  }
+);
+
+// Call to api "n" times for recovering data of all books of author with id "foo-id"
+const authorBooksData = await authorBooksData.query("foo-id").read();
+
+```
+
+Returned sources can be defined as objects containing query callback or catch functions as well:
+
+```js
+
+import { Api } from "@xbyorange/mercury-api";
+
+import { authorsOrigin } from "./authors";
+import { booksOrigin } from "./books";
+
+const authorBooksData = new Selector(
+  {
+    source: authorsOrigin,
+    query: queriedId => ({
+      urlParams: {
+        id: queriedId
+      }
+    })
+  },
+  authorDetails => {
+    return authorDetails.booksIds.map(bookId => ({
+      source: booksOrigin,
+      query: () => ({
+        urlParams: {
+          id: bookId
+        }
+      }),
+      catch: () => Promise.resolve({
+        title: "Error recovering book title"
+      })
+    }))
+  }
+);
+
+const authorBooksData = await authorBooksData.query("foo-id").read();
+
+```
+

--- a/docs/selector/sources-error-handling.md
+++ b/docs/selector/sources-error-handling.md
@@ -1,6 +1,6 @@
 ## Sources error handling
 
-Dependant sources of a Selector can return an error. Then, the full Selector will not be resolved. You can catch those source errors and transform them into a data of your convenience, or even delegate or "retry" that source into another source.
+Dependant sources of a Selector can return an error. Then, the full Selector will not be resolved. You can catch those source errors and transform them into a data of your convenience, or even delegate or "retry" that source into another source or array of sources.
 
 Use the `catch` property of a custom source to catch his errors:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbyorange/mercury",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbyorange/mercury",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Mercury. Reactive CRUD data layer",
   "keywords": [
     "reactive",

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -41,9 +41,9 @@ export class Selector extends Origin {
       const catches = [];
       sourcesOfLevel.forEach(source => {
         if (Array.isArray(source)) {
-          const testObjects = getTestObjects(source);
-          queries.push(testObjects.queries);
-          catches.push(testObjects.catches);
+          const childTestObjects = getTestObjects(source);
+          queries.push(childTestObjects.queries);
+          catches.push(childTestObjects.catches);
         } else {
           const isSourceObject = !!source.source;
           sourceIds.push(isSourceObject ? source.source._id : source._id);

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -7,7 +7,8 @@ import {
   CREATE_METHOD,
   UPDATE_METHOD,
   DELETE_METHOD,
-  seemsToBeSelectorOptions
+  seemsToBeSelectorOptions,
+  areSources
 } from "./helpers";
 
 export class Selector extends Origin {
@@ -64,8 +65,6 @@ export class Selector extends Origin {
   _readAllSourcesAndDispatch(query, extraParams, methodToDispatch) {
     const sourcesResults = [];
     const sources = [];
-    let selectorResult;
-    let selectorResultIsSource;
     const cleanQuery = once(() => {
       this.clean(query);
     });
@@ -86,9 +85,9 @@ export class Selector extends Origin {
       return source[READ_METHOD].dispatch().catch(error => {
         if (hasToCatch) {
           const catchResult = sourceToRead.catch(error, query);
-          if (catchResult._isSource) {
+          if (areSources(catchResult)) {
             sources.push(catchResult);
-            return catchResult[READ_METHOD].dispatch();
+            return readSource(catchResult);
           }
           return catchResult;
         }
@@ -111,21 +110,27 @@ export class Selector extends Origin {
       sources.forEach(source => {
         source.onceClean(cleanQuery);
       });
-      if (selectorResultIsSource) {
-        selectorResult.onceClean(cleanQuery);
-      }
     };
 
     return readSourceIndex(0)
       .then(result => {
-        selectorResult = result;
-        selectorResultIsSource = selectorResult && selectorResult._isSource;
+        const selectorResult = result;
+        const selectorResultIsSource = areSources(selectorResult);
         if (methodToDispatch !== READ_METHOD && !selectorResultIsSource) {
           return Promise.reject(new Error("CUD methods can be used only when returning sources"));
         }
-        return selectorResultIsSource
-          ? selectorResult[methodToDispatch].dispatch(extraParams)
-          : Promise.resolve(selectorResult);
+        if (selectorResultIsSource) {
+          if (methodToDispatch === READ_METHOD) {
+            return readSource(selectorResult);
+          }
+          if (Array.isArray(selectorResult)) {
+            return Promise.all(
+              selectorResult.map(source => source[methodToDispatch].dispatch(extraParams))
+            );
+          }
+          return selectorResult[methodToDispatch].dispatch(extraParams);
+        }
+        return Promise.resolve(selectorResult);
       })
       .then(result => {
         addCleanQueryListeners();

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -79,3 +79,20 @@ export const seemsToBeSelectorOptions = defaultValueOrOptions => {
     defaultValueOrOptions.hasOwnProperty("uuid")
   );
 };
+
+export const isSource = objectToCheck => {
+  return (
+    objectToCheck &&
+    (objectToCheck._isSource === true || (objectToCheck.source && objectToCheck.source._isSource))
+  );
+};
+
+export const areSources = arrayToCheck => {
+  let allAreSources = true;
+  ensureArray(arrayToCheck).forEach(arrayElement => {
+    if (!isSource(arrayElement)) {
+      allAreSources = false;
+    }
+  });
+  return allAreSources;
+};

--- a/test/Selector.dynamic.js
+++ b/test/Selector.dynamic.js
@@ -1,0 +1,199 @@
+const test = require("mocha-sinon-chai");
+
+const { Origin, sources } = require("../src/Origin");
+const { Selector } = require("../src/Selector");
+
+test.describe("Selector returning another sources", () => {
+  let sandbox;
+  let testOriginResult;
+  let testSelectorResult;
+  let testSelector2Result;
+  let updateOriginResult;
+  const TestOrigin = class extends Origin {
+    constructor(options) {
+      super();
+      this._readResult = options.readResult;
+      this._updateResult = options.updateResult;
+    }
+    _read() {
+      return Promise.resolve(this._readResult);
+    }
+    _update() {
+      return Promise.resolve(this._updateResult);
+    }
+  };
+  let testOrigin;
+  let testSelector;
+  let testSelector2;
+  let dynamicSelector;
+
+  test.beforeEach(() => {
+    sandbox = test.sinon.createSandbox();
+    testOriginResult = "read result";
+    updateOriginResult = "updated";
+    testSelectorResult = "foo-selector-result";
+    testSelector2Result = "foo-selector-2-result";
+    testOrigin = new TestOrigin({
+      readResult: testOriginResult,
+      updateResult: updateOriginResult
+    });
+    testSelector = new Selector(testOrigin, () => testSelectorResult, {
+      uuid: "test-selector"
+    });
+    testSelector2 = new Selector(testOrigin, () => testSelector2Result, {
+      uuid: "test-selector-2"
+    });
+    sandbox.spy(testSelector.update);
+    sandbox.spy(testSelector2.update);
+  });
+
+  test.afterEach(() => {
+    sandbox.restore();
+    sources.clear();
+  });
+
+  test.describe("calling to read method", () => {
+    test.describe("when returns one source", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return testSelector;
+        });
+      });
+
+      test.it("should return the result returned by source", () => {
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.equal(testSelectorResult);
+        });
+      });
+    });
+
+    test.describe("when returns multiple sources", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return [testSelector, testSelector2];
+        });
+      });
+
+      test.it("should return the result returned by all sources", () => {
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.deep.equal([testSelectorResult, testSelector2Result]);
+        });
+      });
+    });
+
+    test.describe("when returns multiple sources with queries", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return [
+            {
+              source: testSelector,
+              query: () => "foo"
+            },
+            {
+              source: testSelector2,
+              query: () => "foo2"
+            },
+            {
+              source: testSelector2,
+              query: () => "foo3"
+            }
+          ];
+        });
+      });
+
+      test.it("should return the result returned by all sources", () => {
+        return dynamicSelector.read().then(result => {
+          return test
+            .expect(result)
+            .to.deep.equal([testSelectorResult, testSelector2Result, testSelector2Result]);
+        });
+      });
+    });
+    test.describe("when returns sources recursively", () => {
+      let recursiveSelector;
+      test.beforeEach(() => {
+        recursiveSelector = new Selector(
+          testOrigin,
+          () => {
+            return testSelector2;
+          },
+          {
+            uuid: "recursive-selector"
+          }
+        );
+
+        dynamicSelector = new Selector(testOrigin, () => {
+          return recursiveSelector;
+        });
+      });
+
+      test.it("should return the result returned by last source", () => {
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.equal(testSelector2Result);
+        });
+      });
+    });
+
+    test.describe("when returns multiple sources recursively", () => {
+      let recursiveSelector;
+      test.beforeEach(() => {
+        recursiveSelector = new Selector(
+          testOrigin,
+          () => {
+            return [testSelector2, testSelector];
+          },
+          {
+            uuid: "recursive-selector"
+          }
+        );
+
+        dynamicSelector = new Selector(testOrigin, () => {
+          return recursiveSelector;
+        });
+      });
+
+      test.it("should return the result returned by last sources", () => {
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.deep.equal([testSelector2Result, testSelectorResult]);
+        });
+      });
+    });
+  });
+
+  test.describe("calling to CUD method", () => {
+    test.describe("when returns one origin", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return testOrigin;
+        });
+      });
+
+      test.it("should call to same method of returned source", () => {
+        return dynamicSelector.update().then(result => {
+          return test.expect(result).to.equal(updateOriginResult);
+        });
+      });
+    });
+
+    test.describe("when returns multiple origins", () => {
+      let testOrigin2;
+      let updateOriginResult2;
+      test.beforeEach(() => {
+        updateOriginResult2 = "foo-update-origin-2-result";
+        testOrigin2 = new TestOrigin({
+          readResult: testOriginResult,
+          updateResult: updateOriginResult2
+        });
+        dynamicSelector = new Selector(testOrigin, () => {
+          return [testOrigin, testOrigin2];
+        });
+      });
+
+      test.it("should call to same method of returned source", () => {
+        return dynamicSelector.update().then(result => {
+          return test.expect(result).to.deep.equal([updateOriginResult, updateOriginResult2]);
+        });
+      });
+    });
+  });
+});

--- a/test/Selector.dynamic.js
+++ b/test/Selector.dynamic.js
@@ -81,6 +81,48 @@ test.describe("Selector returning another sources", () => {
       });
     });
 
+    test.describe("when returns another source with catch", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return {
+            source: testSelector,
+            catch: () => Promise.resolve("Foo catch result")
+          };
+        });
+      });
+
+      test.it("should return the result returned by catch", () => {
+        sandbox.stub(testSelector.read, "dispatch").rejects(new Error());
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.equal("Foo catch result");
+        });
+      });
+    });
+
+    test.describe("when returns multiple sources with catch", () => {
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return [
+            {
+              source: testSelector,
+              catch: () => Promise.resolve("Foo catch result")
+            },
+            {
+              source: testSelector2,
+              query: () => "foo2"
+            }
+          ];
+        });
+      });
+
+      test.it("should return the sources results, including result returned by catch", () => {
+        sandbox.stub(testSelector.read, "dispatch").rejects(new Error());
+        return dynamicSelector.read().then(result => {
+          return test.expect(result).to.deep.equal(["Foo catch result", testSelector2Result]);
+        });
+      });
+    });
+
     test.describe("when returns multiple sources with queries", () => {
       test.beforeEach(() => {
         dynamicSelector = new Selector(testOrigin, () => {
@@ -109,6 +151,7 @@ test.describe("Selector returning another sources", () => {
         });
       });
     });
+
     test.describe("when returns sources recursively", () => {
       let recursiveSelector;
       test.beforeEach(() => {

--- a/test/Selector.dynamic.js
+++ b/test/Selector.dynamic.js
@@ -195,5 +195,52 @@ test.describe("Selector returning another sources", () => {
         });
       });
     });
+
+    test.describe("when returns another sources recursively", () => {
+      let recursiveSelector;
+      test.beforeEach(() => {
+        dynamicSelector = new Selector(testOrigin, () => {
+          return testOrigin;
+        });
+
+        recursiveSelector = new Selector(testOrigin, () => {
+          return dynamicSelector;
+        });
+      });
+
+      test.it("should call to same method of last source", () => {
+        return recursiveSelector.update().then(result => {
+          return test.expect(result).to.equal(updateOriginResult);
+        });
+      });
+    });
+
+    test.describe("when returns multiple sources recursively", () => {
+      let testOrigin2;
+      let recursiveSelector;
+      let updateResult2;
+
+      test.beforeEach(() => {
+        updateResult2 = "update-result-2";
+        testOrigin2 = new TestOrigin({
+          readResult: testOriginResult,
+          updateResult: updateResult2
+        });
+
+        dynamicSelector = new Selector(testOrigin, () => {
+          return [testOrigin, testOrigin2];
+        });
+
+        recursiveSelector = new Selector(testOrigin, () => {
+          return dynamicSelector;
+        });
+      });
+
+      test.it("should call to same method of last source", () => {
+        return recursiveSelector.update().then(result => {
+          return test.expect(result).to.deep.equal([updateOriginResult, updateResult2]);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Added
- Selectors can now return an array of sources.
- Selectors can now return sources defined as objects containing `query` and/or `catch` property.

### Fixed
- Fix Sonar code smell.

closes #7 